### PR TITLE
fix: attach custom policy for generic pod_identity entries

### DIFF
--- a/pod_identity.tf
+++ b/pod_identity.tf
@@ -13,6 +13,8 @@ module "pod_identity" {
   policy_statements        = try(each.value.policy_statements, [])
   tags                     = local.tags
 
+  attach_custom_policy = length(try(each.value.policy_statements, [])) > 0
+
   ## Default association for the pod identity
   association_defaults = {
     namespace       = each.value.namespace


### PR DESCRIPTION
## Problem

The generic `module "pod_identity"` (the `for_each = var.pod_identity` block in `pod_identity.tf`) forwards `policy_statements` to the `terraform-aws-modules/eks-pod-identity` submodule but never sets `attach_custom_policy` — which **defaults to `false`** in that submodule (v2.8.1, `variables.tf`).

So any custom `pod_identity` entry that supplies `policy_statements` (rather than a pre-built `managed_policy_arns`) has its statements **silently dropped**. The IAM role, its Pod Identity trust policy, and the association are all created — but the role ends up with **zero permission policies**, so the pod can assume the role yet is denied every API call.

This bit us provisioning a Bedrock-scoped role for a workload: correct trust, correct association, `policy_statements` set — but 0 policies on the role.

The specialized blocks in the same file (`aws_ack_acm_pod_identity`, `aws_argocd_pod_identity`, `aws_eks_ack_controller_pod_identity`) already avoid this by hard-coding `attach_custom_policy = true`. Only the generic path was missing it.

## Fix

Enable the custom policy on the generic block whenever `policy_statements` are supplied:

```hcl
attach_custom_policy = length(try(each.value.policy_statements, [])) > 0
```

- **Backward-compatible:** entries *without* `policy_statements` evaluate to `false` (unchanged).
- Entries *with* `policy_statements` now get the policy created + attached (the intended behaviour).
- Type-safe: references only `policy_statements`, which the `var.pod_identity` object type defines. (`each.value.attach_custom_policy` can't be used — the object type has no such field, so it'd be a static error rather than a `try`-catchable one; hence the length-based auto-enable instead of a passthrough flag.)

`terraform fmt` clean; no variable-schema change.

## Test plan

- A `pod_identity` entry with `policy_statements` now produces a role **with** the custom policy attached (previously 0 policies).
- An entry without `policy_statements` is unchanged (no custom policy).
